### PR TITLE
build: kernel: Add back support for selecting latest clang version

### DIFF
--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -189,7 +189,13 @@ $(INTERNAL_VENDOR_RAMDISK_TARGET): $(TARGET_PREBUILT_INT_KERNEL)
 PATH_OVERRIDE := PATH=$(KERNEL_BUILD_OUT_PREFIX)$(HOST_OUT_EXECUTABLES):$$PATH
 ifeq ($(TARGET_KERNEL_CLANG_COMPILE),true)
     ifneq ($(TARGET_KERNEL_CLANG_VERSION),)
-        KERNEL_CLANG_VERSION := clang-$(TARGET_KERNEL_CLANG_VERSION)
+        ifeq ($(TARGET_KERNEL_CLANG_VERSION),latest)
+            # Set the latest version of clang
+            KERNEL_CLANG_VERSION := $(shell ls -d $(BUILD_TOP)/prebuilts/clang/host/$(HOST_OS)-x86/clang-r* | xargs -n 1 basename | tail -1)
+        else
+            # Find the clang-* directory containing the specified version
+            KERNEL_CLANG_VERSION := clang-$(TARGET_KERNEL_CLANG_VERSION)
+        endif
     else
         # Use the default version of clang if TARGET_KERNEL_CLANG_VERSION hasn't been set by the device config
         KERNEL_CLANG_VERSION := $(LLVM_PREBUILTS_VERSION)


### PR DESCRIPTION
Reference: https://gerrit.aicp-rom.com/c/AICP/vendor_aicp/+/99706

Commit 56f0ef54b8f72ef3ad9303df0d76ea262254dd7c ("tasks: kernel:
Add support for Clang kernel builds") used to select latest clang
version by default if TARGET_KERNEL_CLANG_VERSION was not set

This brings back that logic, just instead of clang-* it is now
clang-r* otherwise it is selecting clang-stable (thanks akhilnarang).

Set TARGET_KERNEL_CLANG_VERSION to latest if you want to use it.

Change-Id: If538ad52943db74e25faf44f02aef1cd204f44ee